### PR TITLE
Fix: GitHub logo link opens in a new tab

### DIFF
--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -36,6 +36,7 @@ function Homepage() {
       <Link
         to={"https://github.com/singodiyashubham87/ScrapeIt"}
         className="absolute top-0 right-0 p-6"
+        target="_blank"  // open link in a new tab
       >
         <img src={ghlogo} alt="small_github_logo" className="h-10"/>
       </Link>

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -155,6 +155,7 @@ const getGreeting = () => {
           <Link
             to={"https://github.com/singodiyashubham87/ScrapeIt"}
             className="absolute top-0 right-0 p-6"
+            target="_blank"  // open link in a new tab
           >
             <img src={ghlogo} alt="small_github_logo" className="h-10 ghlogo-vsm:h-[2.5rem] ghlogo-vvsm:h-[2rem]"/>
           </Link>


### PR DESCRIPTION
fixes #49 